### PR TITLE
add support for time64 libc

### DIFF
--- a/src/register.c
+++ b/src/register.c
@@ -35,6 +35,14 @@
 #include "siproxd.h"
 #include "log.h"
 
+#ifndef TIME_T_INT_FMT
+#ifdef __USE_TIME_BITS64
+#define TIME_T_INT_FMT PRId64
+#else
+#define TIME_T_INT_FMT "ld"
+#endif
+#endif
+
 /* configuration storage */
 extern struct siproxd_config configuration;
 
@@ -336,7 +344,7 @@ int register_client(sip_ticket_t *ticket, int force_lcl_masq) {
          /* check address-of-record ("public address" of user) */
          if (compare_url(url1_to, url2_to)==STS_SUCCESS) {
             DEBUGC(DBCLASS_REG, "found entry for %s@%s <-> %s@%s at "
-                   "slot=%i, exp=%li",
+                   "slot=%i, exp=%" TIME_T_INT_FMT,
                    (url1_contact->username) ? url1_contact->username : "*NULL*",
                    (url1_contact->host) ? url1_contact->host : "*NULL*",
                    (url2_to->username) ? url2_to->username : "*NULL*",


### PR DESCRIPTION
libcs are implementing changes to fix the year 2038 issue on 32 bit
platforms (see [1]). musl libc already went ahead and implemented it,
starting with musl-1.2.0 (see [2]).

This commit adds a new definitions to src/register.c:

TIME_T_INT_FMT

If __USE_TIME_BITS64 is defined (by a time64 libc, see [1]), it's set to
the proper conversions for type int64_t, PRId64.  If __USE_TIME_BITS64
is not defined, the status quo remains unchanged ("%ld" is used).

Note: siproxd uses "%li" instead of "%ld". But in the context of printf etc.
there is no difference, so this commit replaces "%li" with "%ld".

These changes get rid of the new warnings that appeared with musl-1.2.0:

```
In file included from register.c:36:
register.c: In function 'register_client':
register.c:339:33: warning: format '%li' expects argument of type 'long int', but argument 10 has type 'time_t' {aka 'long long int'} [-Wformat=]
  339 |             DEBUGC(DBCLASS_REG, "found entry for %s@%s <-> %s@%s at "
      |                                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
......
  345 |                    i, (long)urlmap[i].expires-time_now);
      |                       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      |                                              |
      |                                              time_t {aka long long int}
log.h:62:55: note: in definition of macro 'DEBUGC'
   62 | #define DEBUGC(C,F...) log_debug(C,__FILE__, __LINE__,F)
      |                                                       ^

```
[1] https://sourceware.org/glibc/wiki/Y2038ProofnessDesign
[2] https://musl.libc.org/time64.html

Signed-off-by: Sebastian Kemper <sebastian_ml@gmx.net>