### PR TITLE
allow reproducible builds

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -388,6 +388,22 @@ dnl    --with-custom-fwmodule
       AC_DEFINE(CUSTOM_FWMODULE, 1,[use custom firewall control module])
       AC_MSG_RESULT($FWLIBS), AC_MSG_RESULT(no))
 
+dnl
+dnl add
+dnl    --enable-reproducible-build
+   reproducible_build="no"
+   AC_MSG_CHECKING(whether to enable a reproducible build)
+   AC_ARG_ENABLE(reproducible-build,
+      [  --enable-reproducible-build
+                          enable reproducible build (default is no)],
+      [  if test "x$enableval" = "xyes"; then
+           reproducible_build="yes"
+           AC_MSG_RESULT(yes)
+         else
+           AC_MSG_RESULT(no)
+         fi
+      ], [AC_MSG_RESULT(no)])
+   AM_CONDITIONAL([REPRODUCIBLE_BUILD],  [test "x$reproducible_build" = "xyes"])
 
 dnl
 dnl Checks for header files.

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -18,11 +18,16 @@
 #    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA 
 #
 
+if REPRODUCIBLE_BUILD
+BUILDDATE="\"unknown\""
+else
+BUILDDATE="\"`date -u '+%Y-%m-%dT%H:%M:%S'`\""
+endif
 
 AM_CFLAGS = -D_GNU_SOURCE $(LTDLDEF) \
             -Werror-implicit-function-declaration \
             -DBUILDSTR="\"`cat .buildno`\"" \
-            -DBUILDDATE="\"`date -u '+%Y-%m-%dT%H:%M:%S'`\""
+            -DBUILDDATE=$(BUILDDATE)
 #&&&INCLUDES = $(LTDLINCL)
 AM_CPPFLAGS = $(LTDLINCL)
 


### PR DESCRIPTION
siproxd sets the current time as BUILDDATE, but then it cannot be built
reproducibly.

This commit adds a configure arg that will forces BUILDDATE to
"unknown", allowing builds to be reproducible.

Default is no, so status quo remains unchanged.

Signed-off-by: Sebastian Kemper <sebastian_ml@gmx.net>