### PR TITLE
Allow builds to be reproducible by default

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -400,11 +400,9 @@ dnl    --enable-reproducible-build
                           enable reproducible build (default is no)],
       [  if test "x$enableval" = "xyes"; then
            reproducible_build="yes"
-           AC_MSG_RESULT(yes)
-         else
-           AC_MSG_RESULT(no)
          fi
-      ], [AC_MSG_RESULT(no)])
+      ])
+   AC_MSG_RESULT($reproducible_build)
    AM_CONDITIONAL(REPRODUCIBLE_BUILD, test "x$reproducible_build" = "xyes")
 
 dnl

--- a/configure.ac
+++ b/configure.ac
@@ -395,6 +395,9 @@ dnl add
 dnl    --enable-reproducible-build
    reproducible_build="no"
    AC_MSG_CHECKING(whether to enable a reproducible build)
+   if test "x$SOURCE_DATE_EPOCH" != "x"; then
+     reproducible_build="yes"
+   fi
    AC_ARG_ENABLE(reproducible-build,
       [  --enable-reproducible-build
                           enable reproducible build (default is no)],


### PR DESCRIPTION
This is a follow-up to PR #2 :

Allow builds to be reproducible by default
without specifying project-specific configure flags
to give distribution packagers an easier time.

If you do not set [`SOURCE_DATE_EPOCH`](https://reproducible-builds.org/specs/source-date-epoch/), it will still include the build date as before.

Note, that this change is split into 2 commits.

This PR was done while working on [reproducible builds for openSUSE](https://en.opensuse.org/openSUSE:Reproducible_Builds).