### PR TITLE
rtpproxy.h: include <sys/time.h> when available

### DIFF
--- a/src/rtpproxy.h
+++ b/src/rtpproxy.h
@@ -20,6 +20,10 @@
 
 /* $Id$ */
 
+#if defined(HAVE_SYS_TIME_H)
+# include <sys/time.h>
+#endif
+
 #define CALLIDNUM_SIZE	256
 #define CALLIDHOST_SIZE	128
 


### PR DESCRIPTION
This notably fixes the build on NetBSD.

Patch originally from pkgsrc (see http://cvsweb.netbsd.org/bsdweb.cgi/pkgsrc/net/siproxd/patches/patch-src_rtpproxy.h?rev=1.1) and improved to include this header only when available.

Tested on NetBSD/amd64.