### PR TITLE
README: also mention NetBSD

### DIFF
--- a/README
+++ b/README
@@ -32,6 +32,7 @@ PREREQUISITES
 - OS of either:
   * Linux (preferred kernel 2.2.x or 2.4.x)
   * FreeBSD
+  * NetBSD
   * OpenBSD
   * SunOS
   * Mac OS X


### PR DESCRIPTION
This trivial change adds NetBSD to the list of Operating Systems where siproxd is known to work.
Thanks!