### PR TITLE
Fix compilation on gcc >= 14

### DIFF
--- a/acinclude.m4
+++ b/acinclude.m4
@@ -340,7 +340,7 @@ dnl pointer to the structure (bad)
 AC_COMPILE_IFELSE(
 [AC_LANG_SOURCE([
   #include <osipparser2/osip_parser.h>
-  main() {
+  int main() {
   osip_message_t t;
   int  e;
   e=t.contacts.nb_elt;


### PR DESCRIPTION
`./configure` fails for gcc >= 14 with the following error

```
checking "libosip prefix"... 
checking for osip_init in -losip2... yes
checking for parser_init in -losipparser2... yes
checking libosip2 version > 3.0.0... *** ERROR: libosip2-3.x.x is required!
```

which in fact is caused by the test program in `ACX_CHECK_LIBOSIP_VERSION` function in `acinclude.m4` due to

```
conftest.c:4:3: error: return type defaults to ‘int’ [-Wimplicit-int]                                                                                                                                                                                                                       
    4 | main() {                                                                                                                                                                                                                                                                            
      | ^~~~                                                              
```

This patch fixes the issue!